### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This R package provides an interface to the C++ library NCL. It can parse
 efficiently NEXUS and Newick file. Currently, the package focuses on retrieving
 the phylogenetic trees included in these files. If you are interested in
 retrieving other kind of data that NEXUS files may include, check out the
-[https://github.com/fmichonneau/phylobase](phylobase) package.
+[phylobase](https://github.com/fmichonneau/phylobase) package.
 
 The functions intended for users are: `read_nexus_phylo()` and
 `read_newick_phylo()`. These functions read NEXUS and Newick files respectively,
@@ -20,7 +20,7 @@ The initial CRAN release for this package is 0.2.0.
 
 Because this package contains some C++ code, it can be tricky to build if you
 are using Windows. You can obtain a version from
-[https://ci.appveyor.com/project/fmichonneau/rncl/build/artifacts](here) (unless
+[here](https://ci.appveyor.com/project/fmichonneau/rncl/build/artifacts) (unless
 the AppVeyor badge on top is gray, in which case you can download an older
 version or come back in a few minutes, or red meaning the current version is
 broken and you need to get an older version). Once in appveyor, look for the


### PR DESCRIPTION
Links to phylobase and the build artifacts had square brackets/parens switched around