### PR TITLE
Avoid GCC 16 -Wstringop-overflow false positive in NxsString

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -7,20 +7,24 @@
 # It is unlikely that you need to modify this file manually.
 
 name: R-hub
-run-name: "${{ github.event.inputs.id }}: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }}"
+run-name: >-
+  ${{ github.event.inputs.id || format('Manual run by @{0}', github.triggering_actor) }}:
+  ${{ github.event.inputs.name || github.event.inputs.config }}
 
 on:
   workflow_dispatch:
     inputs:
       config:
-        description: 'A comma separated list of R-hub platforms to use.'
+        description: >-
+          Comma-separated list of R-hub platforms to use.
+          Full list: https://r-hub.github.io/containers/
         type: string
         default: 'linux,windows,macos'
       name:
-        description: 'Run name. You can leave this empty now.'
+        description: 'Run name. You can leave this empty.'
         type: string
       id:
-        description: 'Unique ID. You can leave this empty now.'
+        description: 'Unique ID. You can leave this empty.'
         type: string
 
 jobs:

--- a/src/ncl/nxsstring.h
+++ b/src/ncl/nxsstring.h
@@ -422,7 +422,7 @@ inline NxsString &NxsString::operator=(
 inline NxsString &NxsString::operator+=(
   const char *s)	/* the C-string to be appended */
 	{
-	append(std::string(s));
+	append(s);
 	return *this;
 	}
 
@@ -442,10 +442,7 @@ inline NxsString &NxsString::operator+=(
 inline NxsString &NxsString::operator+=(
   const char c)	/* the character to append */
 	{
-	char s[2];
-	s[0] = c;
-	s[1] = '\0';
-	append(std::string(s));
+	push_back(c);
 	return *this;
 	}
 


### PR DESCRIPTION
GCC 16.1's tightened -Wstringop-overflow analysis flags a __builtin_memmove "writing into a region of size 0" inlined from std::char_traits<char>::copy, triggered by the append(std::string(...)) pattern in NxsString::operator+= (reported by CRAN gcc-SAN checks).

Rewrite the two suspect overloads to avoid constructing a temporary std::string before appending:
- operator+=(const char *): append(s) directly
- operator+=(const char c): push_back(c)

Both are behavior-preserving and drop the char_traits::copy-from-a- bounded-buffer path that the analyzer mis-reasons about.